### PR TITLE
Add destroy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # .gitignore for Terraform
 config.sh
 
+# Deployment script state file
+*_state.sh
+
 # Temporary files
 config/locust_config.env
 

--- a/deploy_vvs_load_testing_framework.sh
+++ b/deploy_vvs_load_testing_framework.sh
@@ -432,6 +432,10 @@ LOCUST_NAMESPACE=""
 
 if terraform output -raw gke_cluster_name &>/dev/null; then
   DEPLOYED_CLUSTER_NAME=$(terraform output -raw gke_cluster_name)
+  # Currently in terraform directory.
+  cat << EOF >> "../${DEPLOYMENT_ID}_state.sh"
+DEPLOYED_CLUSTER_NAME=${DEPLOYED_CLUSTER_NAME}
+EOF
   echo "GKE Cluster name: $DEPLOYED_CLUSTER_NAME"
 fi
 

--- a/deploy_vvs_load_testing_framework.sh
+++ b/deploy_vvs_load_testing_framework.sh
@@ -14,7 +14,7 @@ source "$CONFIG_FILE"
 
 # Generate dynamic variables
 TIMESTAMP=$(date +%Y%m%d%H%M%S)
-DOCKER_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/locust-docker-repo/locust-load-test:LTF-${TIMESTAMP}"
+DOCKER_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/locust-docker-repo/locust-load-test:LTF-${DEPLOYMENT_ID}-${TIMESTAMP}"
 PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
 
 # Set test type and endpoint access based on ENDPOINT_ACCESS_TYPE

--- a/deploy_vvs_load_testing_framework.sh
+++ b/deploy_vvs_load_testing_framework.sh
@@ -14,7 +14,7 @@ source "$CONFIG_FILE"
 
 # Generate dynamic variables
 TIMESTAMP=$(date +%Y%m%d%H%M%S)
-DOCKER_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/locust-docker-repo/locust-load-test:LTF-${DEPLOYMENT_ID}-${TIMESTAMP}"
+DOCKER_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/locust-docker-repo-${DEPLOYMENT_ID}/locust-load-test:LTF-${TIMESTAMP}"
 PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
 
 # Set test type and endpoint access based on ENDPOINT_ACCESS_TYPE
@@ -180,9 +180,9 @@ gcloud services enable aiplatform.googleapis.com \
 
 # Create Artifact Registry repository
 echo "Creating Artifact Registry repository..."
-if ! gcloud artifacts repositories describe locust-docker-repo --location="${REGION}" --project="${PROJECT_ID}" &>/dev/null; then
+if ! gcloud artifacts repositories describe locust-docker-repo-${DEPLOYMENT_ID} --location="${REGION}" --project="${PROJECT_ID}" &>/dev/null; then
   echo "Creating Artifact Registry repository..."
-  gcloud artifacts repositories create locust-docker-repo --repository-format=docker --location="${REGION}" --project="${PROJECT_ID}"
+  gcloud artifacts repositories create locust-docker-repo-${DEPLOYMENT_ID} --repository-format=docker --location="${REGION}" --project="${PROJECT_ID}"
 else
   echo "Artifact Registry repository already exists."
 fi

--- a/deploy_vvs_load_testing_framework.sh
+++ b/deploy_vvs_load_testing_framework.sh
@@ -434,7 +434,7 @@ if terraform output -raw gke_cluster_name &>/dev/null; then
   DEPLOYED_CLUSTER_NAME=$(terraform output -raw gke_cluster_name)
   # Currently in terraform directory.
   cat << EOF >> "../${DEPLOYMENT_ID}_state.sh"
-DEPLOYED_CLUSTER_NAME=${DEPLOYED_CLUSTER_NAME}
+DEPLOYED_CLUSTER_NAME="${DEPLOYED_CLUSTER_NAME}"
 EOF
   echo "GKE Cluster name: $DEPLOYED_CLUSTER_NAME"
 fi

--- a/destroy.sh
+++ b/destroy.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Load configuration
+CONFIG_FILE="config.sh"
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Configuration file $CONFIG_FILE not found!"
+  echo "Please copy config.template.sh to config.sh and update with your settings."
+  exit 1
+fi
+source "$CONFIG_FILE"
+
+# Determine the workspace name
+WORKSPACE_NAME="$DEPLOYMENT_ID"
+
+# Terraform cleanup
+echo "Destroying Terraform resources..."
+cd terraform
+
+# Select the workspace
+if terraform workspace list | grep -q "$WORKSPACE_NAME"; then
+    terraform workspace select "$WORKSPACE_NAME"
+else
+  echo "Workspace $WORKSPACE_NAME does not exist, skipping terraform destroy"
+  exit 0
+fi
+
+# Destroy Terraform resources
+terraform destroy --auto-approve
+
+# Delete the workspace
+terraform workspace select default
+terraform workspace delete --force "$WORKSPACE_NAME"
+
+cd ..
+
+# Deleting Locust config
+rm -rf config
+
+# Artifact Registry Cleanup
+echo "Cleaning up Artifact Registry repository..."
+gcloud artifacts repositories delete locust-docker-repo-${DEPLOYMENT_ID} --location="$REGION" --project="$PROJECT_ID" --quiet --async
+
+
+
+# Commented out the below code becaues they might be using some of the services before using load testing framework.
+# Disable any enabled services
+# echo "Disabling services..."
+# gcloud services disable aiplatform.googleapis.com \
+#   artifactregistry.googleapis.com \
+#   compute.googleapis.com \
+#   autoscaling.googleapis.com \
+#   container.googleapis.com \
+#   iamcredentials.googleapis.com \
+#   cloudbuild.googleapis.com \
+#   iam.googleapis.com \
+#   servicenetworking.googleapis.com \
+#   --project="${PROJECT_ID}" --quiet
+
+echo "Cleanup complete."


### PR DESCRIPTION
This change request documents the implementation of a new bash script, named `destroy.sh` designed to systematically undo all infrastructure changes deployed by the existing deployment script. This script provides a reliable and automated method for cleanup.

Verified the script in the following scenarios:
* HTTP Public with External IP set to "yes".
* HTTP Public with External IP set to "no".
* PSC(Private Service Connect) with External IP set to "yes".
* PSC(Private Service Connect) with External IP set to "no".